### PR TITLE
Remove CNAME since domain has expired

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-margobra.tech


### PR DESCRIPTION
Going to http://margobra8.github.io redirects you to http://margobra.tech, which is expired.